### PR TITLE
Incorrect case pattern in lookup by pins fixed

### DIFF
--- a/src/escp/commands/lookup.py
+++ b/src/escp/commands/lookup.py
@@ -8,7 +8,7 @@ def lookup_by_pins(pins) -> Commands:
     match pins:
         case 9:
             return Commands_9_Pin()
-        case 24, 48:
+        case 24 | 48:
             return Commands_24_48_Pin()
         case _:
             raise ValueError(f'Invalid number of pins: {pins}')


### PR DESCRIPTION
Case statement should trigger for both 24 and 48. The OR pattern with a pipe character must be used for this (see https://docs.python.org/3/reference/compound_stmts.html#or-patterns).