### PR TITLE
Fixes unexpected behaviour of the draft() method

### DIFF
--- a/src/escp/commands/commands.py
+++ b/src/escp/commands/commands.py
@@ -74,11 +74,14 @@ class Commands(ABC):
     def draft(self, enabled: bool) -> T:
         """Change the print quality to draft or letter quality.
 
+        If true is given as argument, the draft mode is enabled. If set to false
+        (near) letter quality is used.
+
         Point sizes 10.5 and 21 only.
         LQ quality for ESC/P2 and ESC/P.
         NLQ for 9-pin printers.
         """
-        return self._append_cmd('draft', int_to_bytes(1 if enabled else 0))
+        return self._append_cmd('draft', int_to_bytes(0 if enabled else 1))
 
     @abstractmethod
     def is_valid_character_table(self, table: int) -> bool:


### PR DESCRIPTION
Until now, setting `draft(True)` resulted in the command `ESC x 1` being sent. According to the ESC/P standard (see https://files.support.epson.com/pdf/general/escp2ref.pdf page 274), this causes the printer to use (N)LQ (i.e. not draft mode). This corresponds to the behaviour of my printer. The function has now been adapted so that it enables the draft mode for `draft(True)` using `ESC x 0` and the doc-comment of the method explicitly points out this behaviour.

It makes a lot more sense to me that way round :) PS: Thanks for the work you put into this library!